### PR TITLE
Fix concurrent access to update

### DIFF
--- a/checker/stateful_multi.go
+++ b/checker/stateful_multi.go
@@ -2,6 +2,7 @@ package checker
 
 import (
 	"context"
+	"maps"
 )
 
 // StatefulMulti is a health checker that combines multiple stateful health checks.
@@ -104,7 +105,9 @@ func (c *StatefulMulti[ResultType]) Start(
 			update := StatefulMultiUpdate[ResultType]{
 				HealthState:   c.worstState(),
 				lastUpdatedID: recvUpdate.ID,
-				updates:       c.lastUpdates,
+				// We need to make a clone because we don't want to send the map by reference as we
+				// mutate it locally.
+				updates: maps.Clone(c.lastUpdates),
 			}
 			if ctx.Err() != nil {
 				return

--- a/monitor/health.go
+++ b/monitor/health.go
@@ -171,7 +171,11 @@ func (h *HealthKeeper) Start(
 							update.Server.ID(),
 							update.Server.Location,
 						)+
-							fmt.Sprintf("```\n%s\n\n%+v\n```\n", update.Result.LastUpdate().ID, update.UnhealthyChecks())+notificationtemplate.RenderState(h.cfg, h.state),
+							fmt.Sprintf(
+								"```\n%s\n\n%+v\n```\n",
+								update.Result.LastUpdate().ID,
+								update.UnhealthyChecks(),
+							)+notificationtemplate.RenderState(h.cfg, h.state),
 					)
 
 					h.logger.ErrorContext(ctx, "Server became unhealthy.",


### PR DESCRIPTION
Although unlikely to go wrong, it should make a copy before passing it as concurrent map access will crash.